### PR TITLE
fix build on gcc-10 (-fno-common)

### DIFF
--- a/src/process.c
+++ b/src/process.c
@@ -29,6 +29,8 @@
 #include "defines.h"
 #include "process.h"
 
+extern int child;
+
 /*
  * Purpose:
  *	Setup signal handlers for wayV - only manage SIGCHLD at this

--- a/src/process.h
+++ b/src/process.h
@@ -23,7 +23,7 @@
 #ifndef __PROCESS_H__
 #define __PROCESS_H__
 
-int child;
+extern int child;
 
 void setupSignals();
 void destroyZombies(int);


### PR DESCRIPTION
gcc-10 changed the default from -fcommon to fno-common:
  https://gcc.gnu.org/PR85678

As a result build fails as:

    ld: process.o:/build/xannotate/src/process.h:26: multiple definition of `child';
      backend.o:/build/xannotate/src/process.h:26: first defined here

The change moves 'child' definition to .c file.